### PR TITLE
グループコントローラーのルーティング

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   devise_for :users
   root  "messages#index"
   resources :users, only: [:edit, :update, :show]
+  resources :groups, only: [:new, :create, :edit, :update]
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
#What
##作成したグループコントローラーへのルーティング設定

#Why
##サービスの中核をなすチャットグループの基本設定であり、必須と思われるため